### PR TITLE
mia_s5_compute_stats.m : if input is only one file, convert it to cell

### DIFF
--- a/main_functions/mia_s5_compute_stats.m
+++ b/main_functions/mia_s5_compute_stats.m
@@ -35,7 +35,7 @@ else
     sInputs = varargin{1} ;
     % If input is only one file, convert to cell for compatibility with
     % multiple data file processing 
-    if size(sInputs,2) == 1 ; sInputs = mat2cell(sInputs,[1]) ; end;
+    if size(sInputs,1) == 1 ; sInputs = mat2cell(sInputs,[1]) ; end;
     OPTIONS = varargin{2};
 end
 

--- a/main_functions/mia_s5_compute_stats.m
+++ b/main_functions/mia_s5_compute_stats.m
@@ -35,7 +35,7 @@ else
     sInputs = varargin{1} ;
     % If input is only one file, convert to cell for compatibility with
     % multiple data file processing 
-    if size(sInputs,1) == 1 ; sInputs = mat2cell(sInputs,[1]) ; end;
+    if ~iscell(sInputs) ; sInputs = mat2cell(sInputs,[1]) ; end;
     OPTIONS = varargin{2};
 end
 

--- a/main_functions/mia_s5_compute_stats.m
+++ b/main_functions/mia_s5_compute_stats.m
@@ -35,7 +35,7 @@ else
     sInputs = varargin{1} ;
     % If input is only one file, convert to cell for compatibility with
     % multiple data file processing 
-    if size(sInputs,1) == 1 ; sInputs = mat2cell(sInputs,[1]) ; end;
+    if size(sInputs,2) == 1 ; sInputs = mat2cell(sInputs,[1]) ; end;
     OPTIONS = varargin{2};
 end
 


### PR DESCRIPTION
When selecting multiple patients, ```sInputs``` is an 1xn cell array, so ```if size(sInputs,1) == 1``` would cause an error. To make it simple, we can use ```if ~iscell()``` instead.