### PR TITLE
Revert "mia_s5_compute_stats.m : if input is only one file, convert it to cell"

### DIFF
--- a/main_functions/mia_s5_compute_stats.m
+++ b/main_functions/mia_s5_compute_stats.m
@@ -35,7 +35,7 @@ else
     sInputs = varargin{1} ;
     % If input is only one file, convert to cell for compatibility with
     % multiple data file processing 
-    if ~iscell(sInputs) ; sInputs = mat2cell(sInputs,[1]) ; end;
+    if size(sInputs,1) == 1 ; sInputs = mat2cell(sInputs,[1]) ; end;
     OPTIONS = varargin{2};
 end
 


### PR DESCRIPTION
Reverts annesodub/mia#2

@ws1011001, I have re-tested that code after merging and realized that something went wrong on my side. 

The problem is that : if a single file is being processed, sInputs is a single cell, whereas if several files are processed sInputs is a cell array. The point here was to convert the single cell to a cell array such that it is being processed the same way as several ones. 

From my tests, in any case the condition isCell will always be fullfiled (==1), so this alternative does not work on my side.

Would you please describe the error and give me the input that caused the error? 
Thank you.